### PR TITLE
Use a single page for journal/wal files

### DIFF
--- a/src/idbvfs.cpp
+++ b/src/idbvfs.cpp
@@ -398,6 +398,12 @@ struct IdbVfs : public SQLiteVfsImpl<IdbFile> {
 		TRACE_LOG("DELETE %s", zName);
 		int error;
 		emscripten_idb_delete(zName, IDBVFS_SIZE_KEY, &error);
+		for (int i = 0; ; i++) {
+			IdbPage page(zName, i);
+			if (!page.remove()) {
+				break;
+			}
+		}
 		TRACE_LOG("  > %d", !error);
 		return error ? SQLITE_IOERR_DELETE : SQLITE_OK;
 	}

--- a/src/idbvfs.cpp
+++ b/src/idbvfs.cpp
@@ -344,7 +344,6 @@ private:
 		if (journal_data.empty()) {
 			size_t journal_size = file_size.get();
 			if (journal_size > 0) {
-				journal_data.resize(journal_size);
 				IdbPage page(file_name, 0);
 				page.load_into(journal_data);
 			}

--- a/src/idbvfs.cpp
+++ b/src/idbvfs.cpp
@@ -105,6 +105,10 @@ public:
 		return error ? 0 : data_size;
 	}
 
+	int store(const std::vector<uint8_t> data) {
+		return store(data.data(), data.size());
+	}
+
 	bool truncate(sqlite3_int64 new_size) {
 		int sector_size = load();
 		if (sector_size > new_size) {
@@ -263,7 +267,7 @@ struct IdbFile : public SQLiteFileImpl {
 		// journal data is stored in-memory and synced all at once
 		if (!journal_data.empty()) {
 			IdbPage file(file_name, 0);
-			file.store(journal_data.data(), journal_data.size());
+			file.store(journal_data);
 			file_size.set(journal_data.size());
 		}
 		return SQLITE_OK;

--- a/src/idbvfs.cpp
+++ b/src/idbvfs.cpp
@@ -12,18 +12,6 @@
 	#define DISK_SECTOR_SIZE 32
 #endif
 
-// SQLite file format offsets
-#define SQLITE_DB_PAGE_SIZE_OFFSET 16
-#define SQLITE_JOURNAL_PAGE_SIZE_OFFSET 24
-#define SQLITE_WAL_PAGE_SIZE_OFFSET 8
-#define SQLITE_MIN_HEADER_SIZE 28
-
-// Helper macros for byte/math operations
-#define LOAD_16_BE(p) \
-	(((uint8_t *) p)[0] << 8) + (((uint8_t *) p)[1])
-#define LOAD_32_BE(p) \
-	(((uint8_t *) p)[0] << 24) + (((uint8_t *) p)[1] << 16) + (((uint8_t *) p)[2] << 8) + (((uint8_t *) p)[3])
-
 /// Return the minimum value between `a` and `b`
 #define MIN(a, b) \
 	((a) < (b) ? (a) : (b))

--- a/src/idbvfs.cpp
+++ b/src/idbvfs.cpp
@@ -8,7 +8,7 @@
 
 /// Used size for Indexed DB "disk sectors"
 #ifndef DISK_SECTOR_SIZE
-	#define DISK_SECTOR_SIZE 1024
+	#define DISK_SECTOR_SIZE 32
 #endif
 
 // SQLite file format offsets

--- a/tests/emscripten_polyfill.hpp
+++ b/tests/emscripten_polyfill.hpp
@@ -6,7 +6,14 @@ static char _idbvfs_file_name_buffer[1024];
 
 inline void emscripten_idb_exists(const char *db_name, const char *file_id, int* pexists, int *perror) {
 	snprintf(_idbvfs_file_name_buffer, sizeof(_idbvfs_file_name_buffer), "%s/%s", db_name, file_id);
-	*pexists = stat(_idbvfs_file_name_buffer, nullptr) == 0;
+	FILE *f = fopen(_idbvfs_file_name_buffer, "rb");
+	if (f) {
+		fclose(f);
+		*pexists = 1;
+	}
+	else {
+		*pexists = 0;
+	}
 	*perror = 0;
 }
 


### PR DESCRIPTION
For optimized performance, we now store the journal file in memory and only sync it to Indexed DB at once in a single page.